### PR TITLE
Fix copy/cut functions

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -400,302 +400,310 @@ msgstr ""
 "Datei kann nicht geöffnet werden:\n"
 "%s"
 
-#: src/ghex-window.c:338
+#: src/ghex-window.c:339
 msgid "_File"
 msgstr "_Datei"
 
-#: src/ghex-window.c:339
+#: src/ghex-window.c:340
 msgid "_Edit"
 msgstr "_Bearbeiten"
 
-#: src/ghex-window.c:340
+#: src/ghex-window.c:341
 msgid "_View"
 msgstr "_Ansicht"
 
-#: src/ghex-window.c:341
+#: src/ghex-window.c:342
 msgid "_Group Data As"
 msgstr "Daten _gruppieren als"
 
 #. View submenu
-#: src/ghex-window.c:342
+#: src/ghex-window.c:343
 msgid "_Windows"
 msgstr "_Fenster"
 
-#: src/ghex-window.c:343
+#: src/ghex-window.c:344
 msgid "_Help"
 msgstr "_Hilfe"
 
 #. File menu
-#: src/ghex-window.c:346
+#: src/ghex-window.c:347
 msgid "_Open..."
 msgstr "Ö_ffnen …"
 
-#: src/ghex-window.c:347
+#: src/ghex-window.c:348
 msgid "Open a file"
 msgstr "Eine Datei öffnen"
 
-#: src/ghex-window.c:349
+#: src/ghex-window.c:350
 msgid "_Save"
 msgstr "_Speichern"
 
-#: src/ghex-window.c:350
+#: src/ghex-window.c:351
 msgid "Save the current file"
 msgstr "Die aktuelle Datei speichern"
 
-#: src/ghex-window.c:352
+#: src/ghex-window.c:353
 msgid "Save _As..."
 msgstr "Speichern _unter …"
 
-#: src/ghex-window.c:353
+#: src/ghex-window.c:354
 msgid "Save the current file with a different name"
 msgstr "Die aktuelle Datei mit einem anderen Namen speichern"
 
-#: src/ghex-window.c:355
+#: src/ghex-window.c:356
 msgid "Save As _HTML..."
 msgstr "Speichern als _HTML …"
 
-#: src/ghex-window.c:356
+#: src/ghex-window.c:357
 msgid "Export data to HTML source"
 msgstr "Daten nach HTML exportieren"
 
-#: src/ghex-window.c:358
+#: src/ghex-window.c:359
 msgid "_Revert"
 msgstr "Zu_rücksetzen"
 
-#: src/ghex-window.c:359
+#: src/ghex-window.c:360
 msgid "Revert to a saved version of the file"
 msgstr "Zu einer gesicherten Version der Datei zurückkehren"
 
-#: src/ghex-window.c:361
+#: src/ghex-window.c:362
 msgid "_Print"
 msgstr "D_rucken"
 
-#: src/ghex-window.c:362
+#: src/ghex-window.c:363
 msgid "Print the current file"
 msgstr "Aktuelle Datei drucken"
 
-#: src/ghex-window.c:364
+#: src/ghex-window.c:365
 msgid "Print Previe_w..."
 msgstr "Druck_vorschau …"
 
-#: src/ghex-window.c:365
+#: src/ghex-window.c:366
 msgid "Preview printed data"
 msgstr "Eine Druckvorschau zeigen"
 
-#: src/ghex-window.c:367
+#: src/ghex-window.c:368
 msgid "_Close"
 msgstr "S_chließen"
 
-#: src/ghex-window.c:368
+#: src/ghex-window.c:369
 msgid "Close the current file"
 msgstr "Die aktuelle Datei schließen"
 
-#: src/ghex-window.c:370
+#: src/ghex-window.c:371
 msgid "E_xit"
 msgstr "_Beenden"
 
-#: src/ghex-window.c:371
+#: src/ghex-window.c:372
 msgid "Exit the program"
 msgstr "Das Programm beenden"
 
 #. Edit menu
-#: src/ghex-window.c:375
+#: src/ghex-window.c:376
 msgid "_Undo"
 msgstr "_Rückgängig"
 
-#: src/ghex-window.c:376
+#: src/ghex-window.c:377
 msgid "Undo the last action"
 msgstr "Die letzte Aktion rückgängig machen"
 
-#: src/ghex-window.c:378
+#: src/ghex-window.c:379
 msgid "_Redo"
 msgstr "_Wiederherstellen"
 
-#: src/ghex-window.c:379
+#: src/ghex-window.c:380
 msgid "Redo the undone action"
 msgstr "Die rückgängig gemachte Aktion wiederherstellen"
 
-#: src/ghex-window.c:381
+#: src/ghex-window.c:382
 msgid "_Copy"
 msgstr "_Kopieren"
 
-#: src/ghex-window.c:382
+#: src/ghex-window.c:383
 msgid "Copy selection to clipboard"
 msgstr "Markierung in die Zwischenablage kopieren"
 
-#: src/ghex-window.c:384
+#: src/ghex-window.c:385
+msgid "Copy Escaped"
+msgstr "Maskiertes Kopieren"
+
+#: src/ghex-window.c386
+msgid "Copy selection to clipboard as escaped string"
+msgstr "Markierung maskiert in die Zwischenablage kopieren"
+
+#: src/ghex-window.c:388
 msgid "Cu_t"
 msgstr "_Ausschneiden"
 
-#: src/ghex-window.c:385
+#: src/ghex-window.c:389
 msgid "Cut selection"
 msgstr "Markierung ausschneiden"
 
-#: src/ghex-window.c:387
+#: src/ghex-window.c:391
 msgid "Pa_ste"
 msgstr "E_infügen"
 
-#: src/ghex-window.c:388
+#: src/ghex-window.c:392
 msgid "Paste data from clipboard"
 msgstr "Daten aus der Zwischenablage einfügen"
 
-#: src/ghex-window.c:390
+#: src/ghex-window.c:394
 msgid "_Find"
 msgstr "_Suchen"
 
-#: src/ghex-window.c:391
+#: src/ghex-window.c:395
 msgid "Search for a string"
 msgstr "Nach einer Zeichenkette suchen"
 
-#: src/ghex-window.c:393
+#: src/ghex-window.c:397
 msgid "_Advanced Find"
 msgstr "Erweiterte S_uche"
 
-#: src/ghex-window.c:394
+#: src/ghex-window.c:398
 msgid "Advanced Find"
 msgstr "Erweiterte Suche"
 
-#: src/ghex-window.c:396
+#: src/ghex-window.c:400
 msgid "R_eplace"
 msgstr "_Ersetzen"
 
-#: src/ghex-window.c:397
+#: src/ghex-window.c:401
 msgid "Replace a string"
 msgstr "Eine Zeichenkette ersetzen"
 
-#: src/ghex-window.c:399
+#: src/ghex-window.c:403
 msgid "_Goto Byte..."
 msgstr "_Gehe zu Byte …"
 
-#: src/ghex-window.c:400
+#: src/ghex-window.c:404
 msgid "Jump to a certain position"
 msgstr "Zu einer bestimmten Position springen"
 
-#: src/ghex-window.c:402
+#: src/ghex-window.c:406
 msgid "_Preferences"
 msgstr "_Einstellungen"
 
-#: src/ghex-window.c:403
+#: src/ghex-window.c:407
 msgid "Configure the application"
 msgstr "Die Anwendung konfigurieren"
 
 #. View menu
-#: src/ghex-window.c:407
+#: src/ghex-window.c:411
 msgid "_Add View"
 msgstr "Ansicht _hinzufügen"
 
-#: src/ghex-window.c:408
+#: src/ghex-window.c:412
 msgid "Add a new view to the buffer"
 msgstr "Eine neue Ansicht zum Puffer hinzufügen"
 
-#: src/ghex-window.c:410
+#: src/ghex-window.c:414
 msgid "_Remove View"
 msgstr "Ansicht ent_fernen"
 
-#: src/ghex-window.c:411
+#: src/ghex-window.c:415
 msgid "Remove the current view of the buffer"
 msgstr "Aktuelle Ansicht des Puffers entfernen"
 
 #. Help menu
-#: src/ghex-window.c:415
+#: src/ghex-window.c:419
 msgid "_Contents"
 msgstr "_Inhalt"
 
-#: src/ghex-window.c:416
+#: src/ghex-window.c:420
 msgid "Help on this application"
 msgstr "Hilfe zu dieser Anwendung"
 
-#: src/ghex-window.c:418
+#: src/ghex-window.c:422
 msgid "_About"
 msgstr "_Info"
 
-#: src/ghex-window.c:419
+#: src/ghex-window.c:423
 msgid "About this application"
 msgstr "Über diese Anwendung"
 
 #. Edit menu
-#: src/ghex-window.c:426
+#: src/ghex-window.c:430
 msgid "_Insert Mode"
 msgstr "E_infügen-Modus"
 
-#: src/ghex-window.c:427
+#: src/ghex-window.c:431
 msgid "Insert/overwrite data"
 msgstr "Daten einfügen/überschreiben"
 
 #. Windows menu
-#: src/ghex-window.c:431
+#: src/ghex-window.c:435
 msgid "Character _Table"
 msgstr "Zeichen_tabelle"
 
-#: src/ghex-window.c:432
+#: src/ghex-window.c:436
 msgid "Show the character table"
 msgstr "Die Zeichentabelle zeigen"
 
-#: src/ghex-window.c:434
+#: src/ghex-window.c:438
 msgid "_Base Converter"
 msgstr "_Basis-Konverter"
 
-#: src/ghex-window.c:435
+#: src/ghex-window.c:439
 msgid "Open base conversion dialog"
 msgstr "Basenumwandlungsdialog öffnen"
 
-#: src/ghex-window.c:437
+#: src/ghex-window.c:441
 msgid "Type Conversion _Dialog"
 msgstr "Ty_pumwandlungsdialog"
 
-#: src/ghex-window.c:438
+#: src/ghex-window.c:442
 msgid "Show the type conversion dialog in the edit window"
 msgstr "Typumwandlungsdialog im Editorfenster anzeigen"
 
-#: src/ghex-window.c:444 src/ui.c:48
+#: src/ghex-window.c:448 src/ui.c:48
 msgid "_Bytes"
 msgstr "_Byte"
 
-#: src/ghex-window.c:445
+#: src/ghex-window.c:449
 msgid "Group data by 8 bits"
 msgstr "Daten in 8-Bit-Gruppen gruppieren"
 
-#: src/ghex-window.c:446 src/ui.c:49
+#: src/ghex-window.c:450 src/ui.c:49
 msgid "_Words"
 msgstr "_Words"
 
-#: src/ghex-window.c:447
+#: src/ghex-window.c:451
 msgid "Group data by 16 bits"
 msgstr "Daten in 16-Bit-Gruppen gruppieren"
 
-#: src/ghex-window.c:448 src/ui.c:50
+#: src/ghex-window.c:452 src/ui.c:50
 msgid "_Longwords"
 msgstr "_Longwords"
 
-#: src/ghex-window.c:449
+#: src/ghex-window.c:453
 msgid "Group data by 32 bits"
 msgstr "Daten in 32-Bit-Gruppen gruppieren"
 
-#: src/ghex-window.c:787
+#: src/ghex-window.c:791
 #, c-format
 msgid "Offset: %s"
 msgstr "Offset: %s"
 
-#: src/ghex-window.c:790
+#: src/ghex-window.c:794
 #, c-format
 msgid "; %s bytes from %s to %s selected"
 msgstr "; %s Bytes von %s bis %s ausgewählt"
 
-#: src/ghex-window.c:1066
+#: src/ghex-window.c:1070
 #, c-format
 msgid "Activate file %s"
 msgstr "Datei %s aktivieren"
 
-#: src/ghex-window.c:1102
+#: src/ghex-window.c:1106
 #, c-format
 msgid "%s - GHex"
 msgstr "%s - GHex"
 
-#: src/ghex-window.c:1224
+#: src/ghex-window.c:1228
 msgid "Select a file to save buffer as"
 msgstr "Datei zum Abspeichern des Puffers auswählen"
 
-#: src/ghex-window.c:1256
+#: src/ghex-window.c:1260
 #, c-format
 msgid ""
 "File %s exists.\n"
@@ -704,20 +712,20 @@ msgstr ""
 "Datei %s existiert bereits.\n"
 "Wollen Sie diese Datei überschreiben?"
 
-#: src/ghex-window.c:1282 src/ui.c:310
+#: src/ghex-window.c:1286 src/ui.c:321
 #, c-format
 msgid "Saved buffer to file %s"
 msgstr "Puffer in Datei %s gespeichert"
 
-#: src/ghex-window.c:1289
+#: src/ghex-window.c:1293
 msgid "Error saving file!"
 msgstr "Beim Speichern der Datei ist ein Fehler aufgetreten!"
 
-#: src/ghex-window.c:1295
+#: src/ghex-window.c:1299
 msgid "Can't open file for writing!"
 msgstr "Datei kann nicht zum Schreiben geöffnet werden!"
 
-#: src/ghex-window.c:1340
+#: src/ghex-window.c:1344
 #, c-format
 msgid ""
 "File %s has changed since last save.\n"
@@ -726,15 +734,15 @@ msgstr ""
 "Datei %s wurde seit dem letzten Speichern geändert.\n"
 "Wollen Sie die Änderungen speichern?"
 
-#: src/ghex-window.c:1344
+#: src/ghex-window.c:1348
 msgid "Do_n't save"
 msgstr "_Nicht speichern"
 
-#: src/ghex-window.c:1364 src/ui.c:298
+#: src/ghex-window.c:1368 src/ui.c:309
 msgid "You don't have the permissions to save the file!"
 msgstr "Sie haben nicht die Berechtigung, um die Datei zu speichern!"
 
-#: src/ghex-window.c:1368 src/ui.c:303
+#: src/ghex-window.c:1372 src/ui.c:314
 msgid "An error occurred while saving file!"
 msgstr "Beim Speichern der Datei ist ein Fehler aufgetreten!"
 
@@ -1077,32 +1085,32 @@ msgstr ""
 msgid "GHex Website"
 msgstr "GHex-Webseite"
 
-#: src/ui.c:328
+#: src/ui.c:339
 msgid "Select a file to open"
 msgstr "Datei zum Öffnen auswählen"
 
-#: src/ui.c:360
+#: src/ui.c:371
 #, c-format
 msgid "Loaded file %s"
 msgstr "Datei %s geladen"
 
-#: src/ui.c:368
+#: src/ui.c:379
 msgid "Can not open file!"
 msgstr "Datei kann nicht geöffnet werden!"
 
-#: src/ui.c:433
+#: src/ui.c:444
 msgid "Select path and file name for the HTML source"
 msgstr "Pfad und Dateiname für die HTML-Quelle wählen"
 
-#: src/ui.c:465
+#: src/ui.c:476
 msgid "You need to specify a base name for the HTML files."
 msgstr "Sie müssen einen Basisnamen für die HTML-Dateien angeben."
 
-#: src/ui.c:476 src/ui.c:502
+#: src/ui.c:487 src/ui.c:513
 msgid "You don't have the permission to write to the selected path.\n"
 msgstr "Sie haben nicht die Berechtigung, um im gewählten Pfad zu schreiben!\n"
 
-#: src/ui.c:488
+#: src/ui.c:499
 msgid ""
 "Saving to HTML will overwrite some files.\n"
 "Do you want to proceed?"
@@ -1110,12 +1118,12 @@ msgstr ""
 "Das Speichern im HTML-Format wird einige Dateien überschreiben.\n"
 "Wollen Sie fortfahren?"
 
-#: src/ui.c:756
+#: src/ui.c:767
 #, c-format
 msgid "Really revert file %s?"
 msgstr "Wirklich auf Datei %s zurückgreifen?"
 
-#: src/ui.c:770
+#: src/ui.c:781
 #, c-format
 msgid "Reverted buffer from file %s"
 msgstr "Puffer zurückgesetzt auf Datei %s"

--- a/src/ghex-ui.xml
+++ b/src/ghex-ui.xml
@@ -21,6 +21,7 @@
       <menuitem action="EditRedo"/>
       <separator/>
       <menuitem action="EditCopy"/>
+      <menuitem action="EditCopyEscaped"/>
       <menuitem action="EditCut"/>
       <menuitem action="EditPaste"/>
       <separator/>

--- a/src/ghex-window.c
+++ b/src/ghex-window.c
@@ -247,6 +247,7 @@ ghex_window_set_sensitivity (GHexWindow *win)
     ghex_window_set_action_sensitive (win, "EditRedo", allmenus && win->redo_sens);
     ghex_window_set_action_sensitive (win, "EditCut", allmenus);
     ghex_window_set_action_sensitive (win, "EditCopy", allmenus);
+    ghex_window_set_action_sensitive (win, "EditCopyEscaped", allmenus);
     ghex_window_set_action_sensitive (win, "EditPaste", allmenus);
 }
 
@@ -381,6 +382,9 @@ static const GtkActionEntry action_entries [] = {
     { "EditCopy", GTK_STOCK_COPY, N_("_Copy"), "<control>C",
       N_("Copy selection to clipboard"),
       G_CALLBACK (copy_cb) },
+    { "EditCopyEscaped", NULL, N_("Copy Escaped"), NULL,
+      N_("Copy selection to clipboard as escaped string"),
+      G_CALLBACK (copy_escaped_cb) },
     { "EditCut", GTK_STOCK_CUT, N_("Cu_t"), "<control>X",
       N_("Cut selection"),
       G_CALLBACK (cut_cb) },

--- a/src/gtkhex.c
+++ b/src/gtkhex.c
@@ -1479,7 +1479,9 @@ void gtk_hex_delete_selection(GtkHex *gh)
 	if(start != end) {
 		if(start < gh->cursor_pos)
 			gtk_hex_set_cursor(gh, gh->cursor_pos - end + start);
-		hex_document_delete_data(gh->document, MIN(start, end), end - start, TRUE);
+        /* length is end - start + 1. If start and end 
+         * differ by one, two bytes should be deleted. */
+		hex_document_delete_data(gh->document, MIN(start, end), end - start + 1, TRUE);
 	}
 }
 
@@ -1690,11 +1692,13 @@ static void gtk_hex_real_copy_to_clipboard(GtkHex *gh)
 
 	start_pos = MIN(gh->selection.start, gh->selection.end);
 	end_pos = MAX(gh->selection.start, gh->selection.end);
- 
+
 	if(start_pos != end_pos) {
+        /* length is end_pos - start_pos + 1. If start and end 
+         * differ by one, two bytes should be copied. */
 		guchar *text = hex_document_get_data(gh->document, start_pos,
-											 end_pos - start_pos);
-		gtk_clipboard_set_text(klass->clipboard, text, end_pos - start_pos);
+											 (end_pos - start_pos)+1);
+		gtk_clipboard_set_text(klass->clipboard, text, end_pos - start_pos + 1);
 		g_free(text);
 	}
 }

--- a/src/gtkhex.h
+++ b/src/gtkhex.h
@@ -128,6 +128,7 @@ struct _GtkHexClass
 	void (*data_changed)(GtkHex *, gpointer);
 	void (*cut_clipboard)(GtkHex *);
 	void (*copy_clipboard)(GtkHex *);
+	void (*copy_escaped_clipboard)(GtkHex *);
 	void (*paste_clipboard)(GtkHex *);
 };
 
@@ -155,6 +156,7 @@ void gtk_hex_set_geometry(GtkHex *gh, gint cpl, gint vis_lines);
 PangoFontMetrics* gtk_hex_load_font (const char *font_name); 
 
 void gtk_hex_copy_to_clipboard(GtkHex *gh);
+void gtk_hex_copy_escaped_to_clipboard(GtkHex *gh);
 void gtk_hex_cut_to_clipboard(GtkHex *gh);
 void gtk_hex_paste_from_clipboard(GtkHex *gh);
 

--- a/src/hex-document.c
+++ b/src/hex-document.c
@@ -489,7 +489,8 @@ hex_document_get_data(HexDocument *doc, guint offset, guint len)
 	ptr = doc->buffer + offset;
 	if(ptr >= doc->gap_pos)
 		ptr += doc->gap_size;
-	dptr = data = g_malloc(sizeof(guchar)*len);
+    /* allocate for len+1 characters to account for trailing 0x00 */
+	dptr = data = g_malloc(sizeof(guchar)*(len+1));
 	i = 0;
 	while(i < len) {
 		if(ptr >= doc->gap_pos && ptr < doc->gap_pos + doc->gap_size)
@@ -497,6 +498,9 @@ hex_document_get_data(HexDocument *doc, guint offset, guint len)
 		*dptr++ = *ptr++;
 		i++;
 	}
+
+    /* add trailing 0x00 here */
+    *dptr = 0x00;
 
 	return data;
 }

--- a/src/ui.c
+++ b/src/ui.c
@@ -250,6 +250,17 @@ copy_cb (GtkAction *action,
 		gtk_hex_copy_to_clipboard(win->gh);
 }
 
+void
+copy_escaped_cb (GtkAction *action,
+                 gpointer   user_data)
+{
+	GHexWindow *win = GHEX_WINDOW(user_data);
+
+	if(win->gh)
+		gtk_hex_copy_escaped_to_clipboard(win->gh);
+}
+
+
 void 
 cut_cb (GtkAction *action,
         gpointer   user_data)

--- a/src/ui.h
+++ b/src/ui.h
@@ -60,6 +60,7 @@ void quit_app_cb (GtkAction *action, gpointer user_data);
 void undo_cb (GtkAction *action, gpointer user_data);
 void redo_cb (GtkAction *action, gpointer user_data);
 void copy_cb (GtkAction *action, gpointer user_data);
+void copy_escaped_cb (GtkAction *action, gpointer user_data);
 void cut_cb (GtkAction *action, gpointer user_data);
 void paste_cb (GtkAction *action, gpointer user_data);
 void find_cb (GtkAction *action, gpointer user_data);


### PR DESCRIPTION
The length of the selection was previously calculated as (end - start),
which led to the unwanted behavior that if e.g. two bytes were selected,
the length (offset difference) calculated to one and therefore only one
byte was actually copied to the clipboard and deleted from the document
in the case of a cut operation. The current version calculates the
correct length of (end - start) + 1.

Furthermore, a trailing 0x00 is added to the data that are copied to the
clipboard. Otherwise, the paste command has now way of knowing the
length. This still leaves an issue if a series of bytes containing one
or more 0x00 are copied to the clipboard. They are copied correctly, but
the paste command has now way of knowing the correct length in that
case.